### PR TITLE
Add BetterLetter safe job completer

### DIFF
--- a/betterletter-safe-completer/README.md
+++ b/betterletter-safe-completer/README.md
@@ -1,0 +1,19 @@
+# BetterLetter Safe Job Completer
+
+This local Chrome extension processes one paused `docman_delete_original` job at a time. It is fail-closed: a URL, practice, job type, status, job ID, or result mismatch stops the run.
+
+## Install or restore
+
+1. Open `chrome://extensions` in Chrome.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select this `betterletter-safe-completer` folder. If it is already listed, click **Reload** instead.
+4. Pin **BetterLetter Safe Job Completer**.
+
+## Safe use
+
+1. Open the BetterLetter bots dashboard while signed in.
+2. Check the intended practice, job type, and paused status.
+3. Open the extension, enter the exact practice name and ODS ID, and click **Start**.
+4. Supervise the first completion. Click **Stop** immediately if BetterLetter behaves unexpectedly.
+
+The extension is limited to `https://app.betterletter.ai/admin_panel/bots/*`, stores run state only in Chrome local extension storage, and contains no analytics or external network code.

--- a/betterletter-safe-completer/background.js
+++ b/betterletter-safe-completer/background.js
@@ -1,0 +1,30 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === "getTabId") sendResponse({ tabId: sender.tab?.id ?? null });
+});
+
+async function updateBadge(state) {
+  if (!state) return chrome.action.setBadgeText({ text: "" });
+  if (state.active) {
+    const done = state.completedCount || 0;
+    const left = Number.isInteger(state.remainingCount) ? state.remainingCount : "?";
+    await chrome.action.setBadgeBackgroundColor({ color: "#1769e0" });
+    await chrome.action.setBadgeText({ text: `${done}/${left}` });
+    await chrome.action.setTitle({ title: `BetterLetter: ${done} completed, ${left} remaining` });
+  } else if (state.phase === "complete") {
+    await chrome.action.setBadgeBackgroundColor({ color: "#16803a" });
+    await chrome.action.setBadgeText({ text: "✓" });
+    await chrome.action.setTitle({ title: `BetterLetter: complete (${state.completedCount || 0} processed)` });
+  } else if (state.phase === "stopped" && state.message !== "Stopped by user") {
+    await chrome.action.setBadgeBackgroundColor({ color: "#b42318" });
+    await chrome.action.setBadgeText({ text: "!" });
+    await chrome.action.setTitle({ title: `BetterLetter stopped: ${state.message || "check status"}` });
+  } else {
+    await chrome.action.setBadgeText({ text: "" });
+    await chrome.action.setTitle({ title: "BetterLetter Safe Job Completer" });
+  }
+}
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "local" && changes.blRunner) updateBadge(changes.blRunner.newValue);
+});
+chrome.storage.local.get("blRunner").then(({ blRunner }) => updateBadge(blRunner));

--- a/betterletter-safe-completer/content.js
+++ b/betterletter-safe-completer/content.js
@@ -1,0 +1,407 @@
+(() => {
+  const JOB_TYPE = "docman_delete_original";
+  const DASHBOARD = "/admin_panel/bots/dashboard";
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const started = Date.now();
+  let busy = false;
+  const tabId = chrome.runtime.sendMessage({ type: "getTabId" }).then((r) => r?.tabId ?? null).catch(() => null);
+  const norm = (value) => (value || "").replace(/\s+/g, " ").trim();
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  function pageLoadFinished() {
+    if (document.readyState !== "complete") return false;
+    const progress = document.querySelector("#nprogress");
+    return !progress || !visible(progress);
+  }
+
+  function controlDisabled(control) {
+    if (!control || !control.isConnected) return true;
+    const clickable = control.closest("button, a, [role=button]") || control;
+    const style = getComputedStyle(clickable);
+    const classText = `${clickable.className || ""}`.toLowerCase();
+    const disabledMarkup = clickable.matches(":disabled, [disabled], [aria-disabled='true'], [aria-busy='true']") ||
+      Boolean(clickable.querySelector("[disabled], [aria-disabled='true'], [aria-busy='true']"));
+    const disabledClass = /(^|[\s_-])(disabled|loading|opacity-\d+|cursor-not-allowed|grayscale)([\s_-]|$)/.test(classText);
+    return disabledMarkup || disabledClass || style.pointerEvents === "none" ||
+      Number.parseFloat(style.opacity || "1") < 0.75;
+  }
+
+  function labelledValue(labelText) {
+    const label = [...document.querySelectorAll("label")]
+      .find((item) => norm(item.textContent).toLowerCase() === labelText.toLowerCase());
+    if (!label?.parentElement) return null;
+    const value = label.parentElement.querySelector("span.col-span-4.font-bold") ||
+      [...label.parentElement.children].find((item) =>
+      item !== label && item.tagName !== "LABEL");
+    return value ? norm(value.textContent) : null;
+  }
+
+  function detailDocumentId() {
+    const value = labelledValue("Document ID");
+    if (value && /^\d+$/.test(value)) return value;
+    const annotation = document.querySelector('a[href*="/mailroom/annotations/"]');
+    return annotation?.getAttribute("href")?.match(/\/mailroom\/annotations\/(\d+)/)?.[1] || null;
+  }
+
+  function detailStatus() {
+    const value = labelledValue("Status")?.toLowerCase();
+    return value === "paused" || value === "completed" ? value : null;
+  }
+
+  function confirmationModalOpen() {
+    const modal = document.querySelector("#confirm-complete");
+    return Boolean(modal && controlIsRendered(modal));
+  }
+
+  async function state() {
+    try {
+      if (!chrome.runtime?.id) return null;
+      return (await chrome.storage.local.get("blRunner")).blRunner;
+    } catch { return null; }
+  }
+  async function patch(values) {
+    try {
+      if (!chrome.runtime?.id) return;
+      const current = await state();
+      if (current) await chrome.storage.local.set({ blRunner: { ...current, ...values, updatedAt: new Date().toISOString() } });
+    } catch { /* Extension was reloaded; the old content-script context must exit quietly. */ }
+  }
+  const stop = (message) => patch({ active: false, phase: "stopped", message });
+  const visible = (element) => {
+    for (let node = element; node?.nodeType === Node.ELEMENT_NODE; node = node.parentElement) {
+      const style = getComputedStyle(node);
+      if (style.display === "none" || style.visibility === "hidden") return false;
+    }
+    return Boolean(element);
+  };
+  const exact = (text, selector = "button, a, [role=button]") => [...document.querySelectorAll(selector)]
+    .filter((el) => visible(el) && norm(el.value || el.textContent).toLowerCase() === text.toLowerCase());
+
+  function exactDashboard(config) {
+    const url = new URL(location.href);
+    const has = (key, value) => url.searchParams.getAll(key).flatMap((v) => v.split(",")).includes(value);
+    return location.origin === "https://app.betterletter.ai" && url.pathname === DASHBOARD &&
+      has("job_types", JOB_TYPE) && has("practice_ids", config.practiceId) && has("status", "paused");
+  }
+  function rowForJobLink(link, config) {
+    const semantic = link.closest("tr") || link.closest("[role=row]");
+    if (semantic) return semantic;
+    for (let node = link.parentElement; node && node !== document.body; node = node.parentElement) {
+      const text = norm(node.textContent);
+      const uuidLinks = [...node.querySelectorAll("a[href]")]
+        .filter((item) => UUID.test(norm(item.textContent)));
+      if (uuidLinks.length === 1 && text.includes(JOB_TYPE) &&
+          text.includes(config.practiceName) && text.includes(config.practiceId)) {
+        return node;
+      }
+    }
+    return null;
+  }
+  function rowJobs(config) {
+    return [...document.querySelectorAll("a[href]")].filter((link) => {
+      if (!UUID.test(norm(link.textContent))) return false;
+      const row = rowForJobLink(link, config);
+      const text = norm(row?.textContent);
+      return text.includes(JOB_TYPE) && text.includes(config.practiceName) && text.includes(config.practiceId);
+    });
+  }
+  function documentIdForJobLink(link, config) {
+    const row = rowForJobLink(link, config);
+    const annotation = row?.querySelector('a[href*="/mailroom/annotations/"]');
+    const fromHref = annotation?.getAttribute("href")?.match(/\/mailroom\/annotations\/(\d+)/)?.[1];
+    if (fromHref) return fromHref;
+    const labelled = [...(row?.querySelectorAll("a") || [])].map((item) => norm(item.textContent))
+      .find((text) => /^\d{4,}$/.test(text));
+    return labelled || null;
+  }
+  function details(config, status) {
+    const text = norm(document.body?.innerText);
+    return text.includes(`Practice ${config.practiceName}`) && text.includes(`Job Type ${JOB_TYPE}`) &&
+      detailStatus() === status;
+  }
+  function sameJob(actual, expected) {
+    try {
+      const a = new URL(actual), e = new URL(expected);
+      return a.origin === e.origin && a.pathname.replace(/\/+$/, "") === e.pathname.replace(/\/+$/, "");
+    } catch { return false; }
+  }
+  function freshJobUrl(value) {
+    const url = new URL(value);
+    url.searchParams.set("_bl_verify", String(Date.now()));
+    return url.href;
+  }
+  function waitFor(check, timeout = 30000) {
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (value) => { if (!done) { done = true; observer.disconnect(); clearTimeout(timer); resolve(value); } };
+      const test = () => { try { const value = check(); if (value) finish(value); } catch { /* retry on mutation */ } };
+      const observer = new MutationObserver(test);
+      observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
+      const timer = setTimeout(() => finish(null), timeout);
+      test();
+    });
+  }
+
+  function confirmationControls() {
+    const modal = document.querySelector("#confirm-complete");
+    if (!modal || !controlIsRendered(modal)) return [];
+    // BetterLetter renders responsive duplicate controls. They are equivalent
+    // only when they live inside the validated confirmation modal and carry the
+    // exact label; geometry merely chooses the preferred copy when available.
+    return [...modal.querySelectorAll("button, [role=button], a")].filter((button) =>
+      norm(button.value || button.textContent).toLowerCase() === "mark as complete" &&
+      !button.disabled && button.getAttribute("aria-disabled") !== "true" &&
+      controlIsRendered(button));
+  }
+
+  function controlIsRendered(control) {
+    try {
+      if (!control?.isConnected || !visible(control) || control.hidden) return false;
+      for (let node = control; node?.nodeType === Node.ELEMENT_NODE; node = node.parentElement) {
+        if (node.hidden || node.getAttribute("aria-hidden") === "true") return false;
+        const style = getComputedStyle(node);
+        if (style.opacity === "0" || style.pointerEvents === "none") return false;
+      }
+      // Background tabs can report zero geometry even for the active responsive
+      // control. CSS/ARIA state is authoritative for eligibility; geometry is
+      // used only as an optional ranking signal in controlScore().
+      return true;
+    } catch { return false; }
+  }
+
+  function controlScore(control) {
+    try {
+      if (!controlIsRendered(control)) return -1;
+      const rect = control.getBoundingClientRect();
+      const area = Math.max(0, rect.width) * Math.max(0, rect.height);
+      if (!area) return 0;
+      const hit = control.ownerDocument.elementFromPoint(
+        rect.left + rect.width / 2, rect.top + rect.height / 2);
+      return area + ((hit === control || control.contains(hit)) ? 1000000 : 0);
+    } catch { return 0; }
+  }
+
+  async function dashboard(current) {
+    const { config } = current;
+    if (!exactDashboard(config)) return stop("URL filters changed; no action taken.");
+    if (!pageLoadFinished()) {
+      await patch({ message: "Waiting for the dashboard loading bar to finish" });
+      return;
+    }
+    const body = norm(document.body?.innerText);
+    if (Date.now() - started < 2000) return patch({ message: "Waiting for dashboard rows to stabilize" });
+    if (!body.includes(config.practiceName)) return stop("Dashboard does not visibly confirm the configured practice.");
+    const jobs = rowJobs(config);
+    const countMatch = body.match(/\b(\d+)\s+visible rows?\b/i);
+    const remainingCount = countMatch ? Number(countMatch[1]) : jobs.length;
+
+    if (current.currentJob && current.phase === "opening") {
+      const openingAt = Date.parse(current.openingAt || "");
+      const elapsed = Number.isFinite(openingAt) ? Date.now() - openingAt : Infinity;
+      if (elapsed < 5000) {
+        await patch({ remainingCount,
+          message: `Waiting for document ${current.currentDocumentId} to open in this tab` });
+        return;
+      }
+      if (!current.expectedJobUrl) return stop("Selected job URL is missing; no action taken.");
+      await patch({ message: `Background link navigation did not start; opening document ${current.currentDocumentId} directly in this tab` });
+      location.assign(current.expectedJobUrl);
+      return;
+    }
+
+    // history.back() can restore a zero-row LiveView shell before its rows are
+    // hydrated. Never interpret that transient state as an empty queue.
+    if (current.phase === "returning" && remainingCount === 0 && jobs.length === 0) {
+      const returnedAt = Date.parse(current.returnStartedAt || "");
+      const elapsed = Number.isFinite(returnedAt) ? Date.now() - returnedAt : 0;
+      if (elapsed < 10000) {
+        await patch({ message: "Waiting for dashboard rows to repopulate after browser Back" });
+        return;
+      }
+      if (!current.dashboardReloaded) {
+        await patch({ dashboardReloaded: true, message: "Refreshing once to verify the apparent empty queue" });
+        const fresh = new URL(config.dashboardUrl);
+        fresh.searchParams.set("_bl_verify", String(Date.now()));
+        location.replace(fresh.href);
+        return;
+      }
+    }
+
+    if (current.currentJob) {
+      if (jobs.some((link) => norm(link.textContent) === current.currentJob)) {
+        const elapsed = Date.now() - Date.parse(current.confirmedAt || "");
+        if (Number.isFinite(elapsed) && elapsed < 10000) return patch({ remainingCount, message: `Waiting for dashboard to remove ${current.currentJob}` });
+        if (!current.dashboardReloaded) {
+          await patch({ dashboardReloaded: true,
+            message: `Refreshing the dashboard once to verify completed document ${current.currentDocumentId || current.currentJob}` });
+          const fresh = new URL(config.dashboardUrl);
+          fresh.searchParams.set("_bl_verify", String(Date.now()));
+          location.replace(fresh.href);
+          return;
+        }
+        return stop(`Document ${current.currentDocumentId || current.currentJob} is still listed after a fresh dashboard load; check it manually.`);
+      }
+      const processed = [...new Set([...(current.processed || []), current.currentJob])].slice(-500);
+      current = { ...current, currentJob: null, currentDocumentId: null, currentStatus: null,
+        expectedJobUrl: null, openingAt: null, confirmedAt: null, dashboardReloaded: false,
+        completionAttempts: 0, completedCount: (current.completedCount || 0) + 1, processed, remainingCount };
+      await patch(current);
+    }
+    if (remainingCount === 0 && jobs.length === 0) return patch({ active: false, phase: "complete", remainingCount: 0,
+      message: "No matching paused jobs remain." });
+    const link = jobs.find((item) => !(current.processed || []).includes(norm(item.textContent)));
+    if (!link) return stop("No unique safe matching job link was found.");
+    const jobId = norm(link.textContent);
+    const documentId = documentIdForJobLink(link, config);
+    if (!documentId) return stop(`Could not identify the Document ID for job ${jobId}.`);
+    await patch({ currentJob: jobId, currentDocumentId: documentId, currentStatus: "paused",
+      expectedJobUrl: link.href, phase: "opening", remainingCount, dashboardReloaded: false,
+      openingAt: new Date().toISOString(), completionAttempts: 0,
+      message: `Opening document ${documentId}` });
+    await sleep(config.delaySeconds * 1000);
+    // Follow the dashboard's own same-tab navigation, matching the manual process.
+    if (link.target && link.target.toLowerCase() !== "_self") {
+      return stop("Job link is no longer configured for same-tab navigation.");
+    }
+    link.click();
+  }
+
+  async function detail(current) {
+    const { config, currentJob, expectedJobUrl } = current;
+    if (!currentJob || !UUID.test(currentJob)) return stop("Missing or invalid current job ID.");
+    if (!expectedJobUrl || !sameJob(location.href, expectedJobUrl)) return stop("Job URL does not match the dashboard selection.");
+    const pageDocumentId = detailDocumentId();
+    if (!pageDocumentId || pageDocumentId !== current.currentDocumentId) {
+      if (Date.now() - started < 15000) return;
+      return stop(`Job page Document ID ${pageDocumentId || "missing"} does not match selected document ${current.currentDocumentId || "missing"}.`);
+    }
+    const pageStatus = detailStatus();
+    if (pageStatus && pageStatus !== current.currentStatus) await patch({ currentStatus: pageStatus });
+    if (current.phase === "returning") {
+      const returnStartedAt = Date.parse(current.returnStartedAt || "");
+      if (Number.isFinite(returnStartedAt) && Date.now() - returnStartedAt < 10000) return;
+      await patch({ message: "Browser Back did not return to the dashboard; loading the exact filtered dashboard" });
+      location.assign(config.dashboardUrl);
+      return;
+    }
+    // The matching Document ID and labelled completed status are authoritative.
+    // LiveView's cosmetic top progress bar can linger after this DOM update.
+    if (pageStatus === "completed" && (current.completionAttempts || 0) > 0) {
+      await patch({ phase: "returning", currentStatus: "completed",
+        returnStartedAt: new Date().toISOString(),
+        message: `Document ${current.currentDocumentId} is completed; using browser Back` });
+      history.back();
+      return;
+    }
+    if (!pageLoadFinished()) {
+      await patch({ message: `Waiting for document ${current.currentDocumentId || currentJob} to finish loading` });
+      return;
+    }
+    if (current.phase === "verifying_result") {
+      if (details(config, "completed")) {
+        await patch({ phase: "returning", confirmedAt: new Date().toISOString(), returnStartedAt: new Date().toISOString(),
+          message: `Fresh server page confirms ${currentJob} is completed; returning to dashboard` });
+        history.back();
+        return;
+      }
+      if (details(config, "paused")) {
+        if ((current.completionAttempts || 0) >= 2) {
+          return stop(`Fresh server page still shows ${currentJob} paused after two completion attempts.`);
+        }
+        current = { ...current, phase: "retrying" };
+        await patch({ phase: "retrying", confirmedAt: null,
+          message: `Fresh server page still shows ${currentJob} paused; making the one permitted retry` });
+      } else {
+        if (Date.now() - started < 15000) return;
+        return stop("Fresh verification page did not show a clear completed or paused state.");
+      }
+    }
+    if (!details(config, "paused")) {
+      if (details(config, "completed")) {
+        await patch({ phase: "returning", confirmedAt: new Date().toISOString(), returnStartedAt: new Date().toISOString(),
+          message: `${currentJob} is completed; using browser Back to return to dashboard` });
+        history.back();
+        return;
+      }
+      if (Date.now() - started < 15000) return;
+      return stop("Job page did not confirm practice, job type, and paused status.");
+    }
+    if (current.phase === "confirming") {
+      // Recover if the original wait was interrupted (for example by a content
+      // script reload). Never click again from this state: first verify the exact
+      // job against a fresh server-rendered page.
+      const confirmedAt = Date.parse(current.confirmedAt || "");
+      const elapsed = Number.isFinite(confirmedAt) ? Date.now() - confirmedAt : Infinity;
+      if (elapsed < 35000) return;
+      await patch({ phase: "verifying_result",
+        message: `Confirmation wait was interrupted for document ${current.currentDocumentId}; verifying server state` });
+      location.replace(freshJobUrl(expectedJobUrl));
+      return;
+    }
+
+    // A content-script or extension reload can happen after the first click while
+    // BetterLetter's confirmation modal remains open. Resume from that validated
+    // modal instead of returning forever in the persisted `clicked` phase.
+    const manual = exact("MANUALLY COMPLETE JOB");
+    let controls = confirmationControls();
+    let attempts = current.completionAttempts || 0;
+    if (!controls.length) {
+      if (current.phase === "clicked") {
+        controls = await waitFor(() => confirmationControls().length ? confirmationControls() : null, 30000);
+      } else {
+        if (manual.length !== 1 || manual[0].disabled) return stop("Exactly one usable Manually Complete Job control was not found.");
+        attempts += 1;
+        if (attempts > 2) return stop("Two completion attempts were already made.");
+        await patch({ phase: "clicked", completionAttempts: attempts, message: `Opening confirmation for ${currentJob}` });
+        manual[0].click();
+        controls = await waitFor(() => confirmationControls().length ? confirmationControls() : null, 30000);
+      }
+    }
+    if (!controls?.length) return stop("Could not safely identify the Mark as Complete confirmation control.");
+    const ranked = controls.map((control, index) => ({ control, index, score: controlScore(control) }))
+      .sort((a, b) => (b.score - a.score) || (b.index - a.index))
+      .map((entry) => entry.control);
+    const confirm = ranked.find((button) => controlScore(button) >= 0 && !button.disabled);
+    if (!confirm || confirm.disabled) return stop("Confirmation control is disabled.");
+    await patch({ phase: "confirming", confirmedAt: new Date().toISOString(),
+      message: `Confirming document ${current.currentDocumentId}` });
+    confirm.click();
+    const result = await waitFor(() => {
+      if (location.pathname === DASHBOARD) return "dashboard";
+      // BetterLetter greys/disables the original control as its acknowledgement.
+      // Requiring the confirmation modal to have closed prevents racing a button
+      // that was already disabled while the modal was still submitting.
+      if (controlDisabled(manual[0]) && !confirmationModalOpen()) return "manual_disabled";
+      if (details(config, "completed")) return "completed";
+      return null;
+    });
+    if (!result) {
+      await patch({ phase: "verifying_result",
+        message: `No visible result for ${currentJob}; reloading its exact page to verify server state` });
+      location.replace(freshJobUrl(expectedJobUrl));
+      return;
+    }
+    if (result === "manual_disabled" || result === "completed") {
+      await patch({ phase: "returning", returnStartedAt: new Date().toISOString(),
+        message: `Manual completion control is disabled for ${currentJob}; using browser Back` });
+      history.back();
+    }
+  }
+
+  async function tick() {
+    if (busy) return;
+    busy = true;
+    try {
+      const current = await state();
+      if (!current?.active || current.targetTabId !== await tabId) return;
+      if (Date.now() - Date.parse(current.startedAt) > 8 * 60 * 60 * 1000) return stop("Eight-hour safety limit reached.");
+      if (location.pathname === DASHBOARD) await dashboard(current); else await detail(current);
+    } catch (error) {
+      if (!chrome.runtime?.id || String(error).includes("Extension context invalidated")) return;
+      await stop(`Unexpected error: ${error?.message || String(error)}`);
+    }
+    finally { busy = false; }
+  }
+  setTimeout(tick, 500);
+  setInterval(tick, 1000);
+})();

--- a/betterletter-safe-completer/icon.svg
+++ b/betterletter-safe-completer/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#1769e0"/>
+  <path d="M34 65l19 19 41-44" fill="none" stroke="#fff" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/betterletter-safe-completer/manifest.json
+++ b/betterletter-safe-completer/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "BetterLetter Safe Job Completer",
+  "version": "1.9.4",
+  "description": "Safely completes explicitly filtered BetterLetter docman_delete_original jobs.",
+  "permissions": ["storage", "activeTab"],
+  "host_permissions": ["https://app.betterletter.ai/admin_panel/bots/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "BetterLetter Safe Job Completer"
+  },
+  "background": { "service_worker": "background.js" },
+  "content_scripts": [
+    {
+      "matches": ["https://app.betterletter.ai/admin_panel/bots/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/betterletter-safe-completer/popup.html
+++ b/betterletter-safe-completer/popup.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Safe Job Completer</title>
+  <style>
+    html { width: 372px; max-width: 372px; overflow-x: hidden; }
+    body { box-sizing: border-box; font: 14px system-ui; margin: 16px; width: 340px; max-width: 340px; color: #09213f; overflow-x: hidden; }
+    h1 { font-size: 17px; margin: 0 0 12px; }
+    label { display: block; font-weight: 650; margin-top: 10px; }
+    input { box-sizing: border-box; width: 100%; padding: 8px; margin-top: 4px; }
+    .fixed { background: #f1f4f8; color: #42526a; }
+    .actions { display: flex; gap: 8px; margin-top: 14px; }
+    button { border: 0; border-radius: 6px; padding: 9px 13px; font-weight: 700; cursor: pointer; }
+    #start { background: #1769e0; color: white; }
+    #stop { background: #d92d20; color: white; }
+    #status { box-sizing: border-box; background: #f5f7fa; border-radius: 6px; line-height: 1.45; margin-top: 12px; max-width: 340px; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere; }
+    .warning { color: #8a3b00; font-size: 12px; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>BetterLetter Safe Completer</h1>
+  <label>Practice name<input id="practiceName" value="Glenlyn Medical Centre"></label>
+  <label>Practice ODS ID<input id="practiceId" value="H81078"></label>
+  <label>Job type<input class="fixed" value="docman_delete_original" disabled></label>
+  <label>Delay between jobs (seconds)<input id="delaySeconds" type="number" min="2" max="120" value="2"></label>
+  <div class="warning">Start only after checking the filtered dashboard. The run stops on any mismatch or uncertain result.</div>
+  <div class="actions"><button id="start">Start</button><button id="stop">Stop</button></div>
+  <div id="status">Loading…</div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/betterletter-safe-completer/popup.js
+++ b/betterletter-safe-completer/popup.js
@@ -1,0 +1,77 @@
+const $ = (id) => document.getElementById(id);
+
+function dashboardUrl(practiceId) {
+  const url = new URL("https://app.betterletter.ai/admin_panel/bots/dashboard");
+  url.searchParams.set("job_types", "docman_delete_original");
+  url.searchParams.set("practice_ids", practiceId);
+  url.searchParams.set("status", "paused");
+  return url.href;
+}
+
+function isExactDashboard(value, practiceId) {
+  try {
+    const url = new URL(value);
+    return url.origin === "https://app.betterletter.ai" &&
+      url.pathname === "/admin_panel/bots/dashboard" &&
+      url.searchParams.get("job_types") === "docman_delete_original" &&
+      url.searchParams.get("practice_ids") === practiceId &&
+      url.searchParams.get("status") === "paused";
+  } catch { return false; }
+}
+
+async function render() {
+  const { blRunner: state = {} } = await chrome.storage.local.get("blRunner");
+  if (state.config) {
+    $("practiceName").value = state.config.practiceName || "";
+    $("practiceId").value = state.config.practiceId || "";
+    $("delaySeconds").value = state.config.delaySeconds || 2;
+  }
+  $("status").textContent = [
+    `Extension version: ${chrome.runtime.getManifest().version}`,
+    `State: ${state.active ? "RUNNING" : "stopped"}`,
+    `Completed this run: ${state.completedCount || 0}`,
+    `Remaining: ${Number.isInteger(state.remainingCount) ? state.remainingCount : "waiting to count"}`,
+    `Current document ID: ${state.currentDocumentId || "none"}`,
+    `Job status: ${state.currentStatus || "waiting"}`,
+    `Job UUID: ${state.currentJob || "none"}`,
+    `Completion attempts: ${state.completionAttempts || 0}/2`,
+    `Message: ${state.message || "Ready"}`
+  ].join("\n");
+}
+
+$("start").addEventListener("click", async () => {
+  const practiceName = $("practiceName").value.trim();
+  const practiceId = $("practiceId").value.trim().toUpperCase();
+  const delaySeconds = Math.max(2, Math.min(120, Number($("delaySeconds").value) || 2));
+  if (!practiceName || !/^[A-Z][A-Z0-9]{4,9}$/.test(practiceId)) {
+    $("status").textContent = "Enter a practice name and valid ODS ID.";
+    return;
+  }
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id || !tab.url?.startsWith("https://app.betterletter.ai/admin_panel/bots/")) {
+    $("status").textContent = "Open the BetterLetter bots dashboard in the active tab first.";
+    return;
+  }
+  const blRunner = {
+    active: true, targetTabId: tab.id, runId: crypto.randomUUID(),
+    startedAt: new Date().toISOString(), completedCount: 0, remainingCount: null,
+    currentJob: null, currentDocumentId: null, currentStatus: null,
+    expectedJobUrl: null, openingAt: null, confirmedAt: null, completionAttempts: 0,
+    phase: "dashboard", processed: [], message: "Starting on filtered dashboard",
+    config: { practiceName, practiceId, jobType: "docman_delete_original", delaySeconds,
+      dashboardUrl: dashboardUrl(practiceId) }
+  };
+  await chrome.storage.local.set({ blRunner });
+  if (!isExactDashboard(tab.url, practiceId)) await chrome.tabs.update(tab.id, { url: blRunner.config.dashboardUrl });
+  render();
+});
+
+$("stop").addEventListener("click", async () => {
+  const { blRunner = {} } = await chrome.storage.local.get("blRunner");
+  await chrome.storage.local.set({ blRunner: { ...blRunner, active: false, currentJob: null,
+    phase: "stopped", message: "Stopped by user" } });
+  render();
+});
+
+chrome.storage.onChanged.addListener(render);
+render();


### PR DESCRIPTION
## What changed

- adds the BetterLetter Safe Job Completer Manifest V3 extension
- processes explicitly filtered paused `docman_delete_original` jobs one at a time
- validates practice, ODS ID, job UUID, Document ID, and exact status transitions
- handles confirmation modals, background tabs, stale dashboard history, and transient LiveView states
- provides local progress, stop controls, and fail-closed safety messaging

## Why

Completing these paused BetterLetter jobs manually requires repetitive navigation and confirmation. This extension reduces active manual effort while stopping on ambiguous page state rather than risking the wrong job.

## Validation

- `node --check betterletter-safe-completer/content.js`
- `node --check betterletter-safe-completer/background.js`
- `node --check betterletter-safe-completer/popup.js`
- manifest parsed and all referenced files verified
